### PR TITLE
Runs a supervised version of Mangoex

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
 ```elixir
 def deps do
-  [{:mangoex, "~> 0.1.9"}]
+  [{:mangoex, "~> 0.1.10"}]
 end
 ```
 

--- a/lib/mangoex.ex
+++ b/lib/mangoex.ex
@@ -3,6 +3,10 @@ defmodule Mangoex do
   use Application
 
   def start(_type, _args) do
-    Mangoex.Client.start_link
+    import Supervisor.Spec, warn: false
+
+    Supervisor.start_link([worker(Mangoex.Client, [])],
+      strategy: :one_for_one,
+      name: Mangoex.Supervisor)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Mangoex.Mixfile do
 
   def project do
     [app: :mangoex,
-     version: "0.1.9",
+     version: "0.1.10",
      description: "Elixir wrapper for the MangoPay API",
      package: package(),
      elixir: "~> 1.4",


### PR DESCRIPTION
Starts the `Mangoex.Client` under a supervisor using the `one_for_one` strategy.

Tested by running locally and whilst running `:observer.start` and looking in Applications I could see that `Elixir.Mangoex.Client` is spawned via `Elixir.Mangoex.Supervisor` and if I kill the process another one immediately replaces it.