### PR TITLE
Enable runtime configuration of `api_base` (#1)

### DIFF
--- a/lib/mangoex/api/base.ex
+++ b/lib/mangoex/api/base.ex
@@ -1,6 +1,4 @@
 defmodule Mangoex.API.Base do
-  @api_base Application.fetch_env!(:mangoex, :api_base)
-
   def request(:auth, client_id, client_pass) do
     token = encode_auth(client_id, client_pass)
 
@@ -83,7 +81,7 @@ defmodule Mangoex.API.Base do
   end
 
   defp api_url(url) do
-    @api_base <> url
+    Application.fetch_env!(:mangoex, :api_base) <> url
   end
 
   defp encode_auth(client_id, client_password) do


### PR DESCRIPTION
It is very common to want to be able to configure a library based on the
runtime environment. For instance, use the mangopay sandbox in staging,
but not in production.

By using a module attribute to store the configuration in the module, we
bind it to a compile-time value.

This commit removes the module variable, calling
`Application.fetch_env!/2` every time we build a url. This should not
impact performance (this call is very cheap), and lets clients of the
library set whatever value they want at runtime.